### PR TITLE
Fix cursor report and dch

### DIFF
--- a/tmt.c
+++ b/tmt.c
@@ -181,11 +181,16 @@ HANDLER(ich)
 HANDLER(dch)
     size_t n = P1(0); /* XXX use MAX */
     if (n > s->ncol - c->c) n = s->ncol - c->c;
+    else if (n == 0) return;
 
     memmove(l->chars + c->c, l->chars + c->c + n,
             (s->ncol - c->c - n) * sizeof(TMTCHAR));
 
-    clearline(vt, l, s->ncol - c->c - n, s->ncol);
+    clearline(vt, l, s->ncol - n, s->ncol);
+    /* VT102 manual says the attribute for the newly empty characters
+     * should be the same as the last character moved left, which isn't
+     * what clearline() currently does.
+     */
 }
 
 HANDLER(el)

--- a/tmt.c
+++ b/tmt.c
@@ -228,7 +228,7 @@ HANDLER(rep)
 
 HANDLER(dsr)
     char r[BUF_MAX + 1] = {0};
-    snprintf(r, BUF_MAX, "\033[%zd;%zdR", c->r, c->c);
+    snprintf(r, BUF_MAX, "\033[%zd;%zdR", c->r + 1, c->c + 1);
     CB(vt, TMT_MSG_ANSWER, (const char *)r);
 }
 


### PR DESCRIPTION
* I think DSR cursor position reporting is 1-based (which would be consistent with the cursor positioning, I think).  Of note, the "resize" command gets the wrong size with the 0-based position report.
* DCH deletes `n` characters, shifting the ones to the right of the cursor leftward.  This should create a "gap" on the right margin of `n` characters, right?  (See, e.g., the DCH description in the [VT102 User Guide](https://vt100.net/docs/vt102-ug/chapter5.html).)